### PR TITLE
Hardcode MySql version to 5.5.29

### DIFF
--- a/src/main/java/io/cloudsoft/socialapps/drupal/examples/BasicDrupalApp.java
+++ b/src/main/java/io/cloudsoft/socialapps/drupal/examples/BasicDrupalApp.java
@@ -37,6 +37,7 @@ public class BasicDrupalApp extends AbstractApplication {
     public BasicDrupalApp() {
         Map mysqlConf = MutableMap.of("creationScriptContents", SCRIPT);
         mySqlNode = new MySqlNode(mysqlConf, this);
+        mySqlNode.setConfig(MySqlNode.SUGGESTED_VERSION, "5.5.29");
 
         drupal = new Drupal(this);
         drupal.setConfig(Drupal.DATABASE_HOST, "127.0.0.1");

--- a/src/main/java/io/cloudsoft/socialapps/drupal/examples/ClusteredDrupalApp.java
+++ b/src/main/java/io/cloudsoft/socialapps/drupal/examples/ClusteredDrupalApp.java
@@ -46,6 +46,7 @@ public class ClusteredDrupalApp extends AbstractApplication {
     public ClusteredDrupalApp() {
         Map mysqlConf = MutableMap.of("creationScriptContents", SCRIPT);
         mySqlNode = new MySqlNode(mysqlConf, this);
+        mySqlNode.setConfig(MySqlNode.SUGGESTED_VERSION, "5.5.29");
 
         ConfigurableEntityFactory<Drupal> drupalFactory = new BasicConfigurableEntityFactory<Drupal>(Drupal.class);
         drupalFactory.setConfig(Drupal.DATABASE_UP, attributeWhenReady(mySqlNode, MySqlNode.SERVICE_UP));

--- a/src/test/java/io/cloudsoft/socialapps/drupal/DrupalTest.java
+++ b/src/test/java/io/cloudsoft/socialapps/drupal/DrupalTest.java
@@ -43,6 +43,7 @@ public class DrupalTest {
 
         Map mysqlConf = MutableMap.of("creationScriptContents", SCRIPT);
         MySqlNode mySqlNode = new MySqlNode(mysqlConf, app);
+        mySqlNode.setConfig(MySqlNode.SUGGESTED_VERSION, "5.5.29");
 
         Drupal  drupal = new Drupal(app);
         drupal.setConfig(Drupal.DATABASE_HOST, "127.0.0.1");


### PR DESCRIPTION
- The default in brooklyn 0.5.0-M1 is 5.5.28 which is no longer available for download from the official MySql site
- Not nice to hard-code a version here, but required to make it work! We should remove this config when we next bump the brooklyn version.

---

The live test still fails for me though. But I don't understand how it ever worked. In `DrupalSshDriver.install`, it does `sudo("mkdir /etc/postfix")` and then `getLocation().copyTo(new ByteArrayInputStream(postfixConfig.getBytes()), "/etc/postfix/main.cf")`. But the latter will be run as the drupal user, while the directory was created as root user. So the copyTo command will presumably always fail with insufficient permissions to write to that directory. Or am I missing something?

I haven't tried to fix that in this pull request.
