### PR TITLE
Tidy WordpressSshDriver package installs

### DIFF
--- a/src/main/java/io/cloudsoft/socialapps/wordpress/WordpressSshDriver.java
+++ b/src/main/java/io/cloudsoft/socialapps/wordpress/WordpressSshDriver.java
@@ -58,22 +58,9 @@ public class WordpressSshDriver extends AbstractSoftwareProcessSshDriver impleme
 
         List<String> commands = new LinkedList<String>();
 
-        commands.add(BashCommands.installPackage(of("yum", "httpd"), null));
-
-        commands.add(alternatives(installPackage(of("yum", "php"), null)));
-//                installPackage("php")), "php/php53 not available"));
-
-        commands.add(alternatives(Arrays.asList(
-                installPackage(of("yum", "php-mysql"), null))));
-//                installPackage("php-mysql")), "php/php53 mysql not available"));
-
-        commands.add(alternatives(Arrays.asList(
-                installPackage(of("yum", "php-gd"), null))));
-//                installPackage("php-gd")), "php/php53 gd not available"));
-
-        // TODO When adding apt support:
-//        commands.add(installPackage(of("apt", "libapache2-mod-php5"), null));
-//        commands.add(installPackage(of("apt", "libapache2-mod-auth-mysql"), null));
+        commands.add(BashCommands.installPackage(of(
+                "yum", "httpd php php-mysql php-gd",
+                "apt", "apache2 php5 php5-mysql php5-gd php-mbstring libapache2-mod-php5 libapache2-mod-auth-mysql"), null));
 
         // as per willomitzer comment at http://googolflex.com/?p=482 (only needed if selinux is on this box)
         commands.add(ok(sudo("setsebool -P httpd_can_network_connect 1")));

--- a/src/test/java/io/cloudsoft/socialapps/wordpress/WordpressEc2LiveTest.java
+++ b/src/test/java/io/cloudsoft/socialapps/wordpress/WordpressEc2LiveTest.java
@@ -69,4 +69,11 @@ public class WordpressEc2LiveTest extends AbstractEc2LiveTest {
     public void test_CentOS_6_3() throws Exception {
         super.test_CentOS_6_3();
     }
+    
+    // TODO Fails because /etc/init.d/httpd not found; see fixme comments at top of WordpressSshDriver
+    @Override
+    @Test(groups = {"Live"}, enabled=false)
+    public void test_Ubuntu_12_0() throws Exception {
+        super.test_Ubuntu_12_0();
+    }
 }


### PR DESCRIPTION
- Simplify for CentOS/RHEL
- Add back in for apt-get
- And test_Ubuntu_12_0 (disabled, because customize command not written to work with that yet).
